### PR TITLE
spi-ch341-usb.c: add missing linux/gpio/driver.h include for gpio_chip

### DIFF
--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -48,6 +48,7 @@
 #include <linux/usb.h>
 #include <linux/spi/spi.h>
 #include <linux/gpio.h>
+#include <linux/gpio/driver.h>
 #include <linux/irq.h>
 
 /** 


### PR DESCRIPTION
Hi all,
I hope this is the right place to ask for pull requests. The current driver situation for this chip is so confusing :D But this fork seams to be the most fitting for my project needs.

This PR adds an missing include (linux/gpio/driver.h) for gpio_chip at least for 6.5.7-arch1-1 kernel

Without I get the following error:

make -C /lib/modules/6.5.7-arch1-1/build M=/foo/foo/spi-ch341-usb  modules
make[1]: Entering directory '/usr/lib/modules/6.5.7-arch1-1/build'
  CC [M]  /foo/foo/spi-ch341-usb/spi-ch341-usb.o
/foo/foo/spi-ch341-usb/spi-ch341-usb.c:191:30: error: field ‘gpio’ has incomplete type
  191 |     struct gpio_chip         gpio;                              // chip descriptor for GPIOs
  
Are there any intentions to get this driver mainlined? Or to make it more configurable? Maybe with the help of device tree or some user space options?

Greets,
Bernhard